### PR TITLE
operators: add a Share operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+**v0.3.0 - Beryllium:**
+
+- new Share operator
+
 **v0.2.1 - Lithium:**
 
 - Enforce the call of onNext in a determinitisc way

--- a/Sources/AsyncSequences/AsyncSequences+Empty.swift
+++ b/Sources/AsyncSequences/AsyncSequences+Empty.swift
@@ -5,8 +5,6 @@
 //  Created by Thibault Wittemberg on 31/12/2021.
 //
 
-import Foundation
-
 public extension AsyncSequences {
     /// `Empty` is an AsyncSequence that immediately finishes without emitting values.
     /// 

--- a/Sources/AsyncSequences/AsyncSequences+Merge.swift
+++ b/Sources/AsyncSequences/AsyncSequences+Merge.swift
@@ -90,7 +90,6 @@ public struct AsyncMergeSequence<UpstreamAsyncSequence: AsyncSequence>: AsyncSeq
     //    }
 
     public struct Iterator: AsyncIteratorProtocol {
-
         var downstreamIterator: AsyncStreams.Passthrough<UpstreamElement>.AsyncIterator
         let upstreamAsyncSequenceRegulators: [ConcurrentAccessRegulator<UpstreamAsyncSequence>]
         // let elementCounter = ElementCounter()

--- a/Sources/AsyncStreams/AsyncStreams+Passthrough.swift
+++ b/Sources/AsyncStreams/AsyncStreams+Passthrough.swift
@@ -43,7 +43,7 @@ public final class AsyncPassthroughStream<Element>: Stream, @unchecked Sendable 
     // because of its async nature. Doing so, it means that we could call `send` while the registration is not done and we
     // would loose the value.
     let serialQueue = DispatchQueue(label: UUID().uuidString)
-    
+
     let continuations = AsyncStreams.Continuations<Element>()
 
     public init() {}

--- a/Sources/AsyncStreams/AsyncStreams+Replay.swift
+++ b/Sources/AsyncStreams/AsyncStreams+Replay.swift
@@ -63,7 +63,7 @@ public final class AsyncReplayStream<Element>: Stream, @unchecked Sendable {
     // because of its async nature. Doing so, it means that we could call `send` while the registration is not done and we
     // would loose the value.
     let serialQueue = DispatchQueue(label: UUID().uuidString)
-    
+
     let continuations = AsyncStreams.Continuations<Element>()
     let storage: Storage
 

--- a/Sources/AsyncStreams/AsyncStreams.swift
+++ b/Sources/AsyncStreams/AsyncStreams.swift
@@ -17,7 +17,7 @@ public enum AsyncStreams {}
 extension AsyncStreams {
     // Continuations can be accessed in a concurrent context. It is up to the caller to ensure
     // the usage in a safe way (cf Passthrough, CurrrentValue and Replay)
-    final class Continuations<Element>{
+    final class Continuations<Element> {
         var continuations = [AnyHashable: AsyncThrowingStream<Element, Error>.Continuation]()
 
         func send(_ element: Element) {

--- a/Sources/Internal/ConcurrentAccessRegulator.swift
+++ b/Sources/Internal/ConcurrentAccessRegulator.swift
@@ -59,9 +59,9 @@ final class ConcurrentAccessRegulator<UpstreamAsyncSequence: AsyncSequence>: @un
         do {
             let next = try await self.upstreamAsyncIterator?.next()
             await self.onNext(next)
-            
+
             await self.gate.unlock()
-            
+
             // yield allows to promote other tasks to resume, giving a chance to request a next element
             await Task.yield()
         } catch is CancellationError {

--- a/Sources/Operators/AsyncSequence+Multicast.swift
+++ b/Sources/Operators/AsyncSequence+Multicast.swift
@@ -18,7 +18,7 @@ public extension AsyncSequence {
     ///     let multicastedAsyncSequence = ["First", "Second", "Third"]
     ///         .asyncElements
     ///         .map { ($0, Int.random(in: 0...100)) }
-    ///         .handleEvents(onElement: { print("AsyncSequence produces: ($0)") })
+    ///         .handleEvents(onElement: { print("AsyncSequence produces: \($0)") })
     ///         .multicast(stream)
     ///
     ///     Task {

--- a/Sources/Operators/AsyncSequence+Multicast.swift
+++ b/Sources/Operators/AsyncSequence+Multicast.swift
@@ -44,7 +44,8 @@ public extension AsyncSequence {
     ///     // Stream 2 received: ("Third", 61)
     ///     // Stream 1 received: ("Third", 61)
     /// ```
-    /// In this example, the output shows that the upstream async sequence produces each random value only one time, and then sends the value to both client loops.
+    /// In this example, the output shows that the upstream async sequence produces each random value only one time,
+    /// and then sends the value to both client loops.
     ///
     /// - Parameter stream: A `Stream` to deliver elements to downstream client loops.
     func multicast<S: Stream>(_ stream: S) -> AsyncMulticastSequence<Self, S> where S.Element == Element {
@@ -79,7 +80,7 @@ where UpstreamAsyncSequence.Element == DownstreamStream.Element {
 
     /// Automates the process of connecting the multicasted async sequence.
     ///
-    ///```
+    /// ```
     ///     let stream = AsyncStreams.Passthrough<(String, Int)>()
     ///     let multicastedAsyncSequence = ["First", "Second", "Third"]
     ///         .asyncElements

--- a/Sources/Operators/AsyncSequence+Share.swift
+++ b/Sources/Operators/AsyncSequence+Share.swift
@@ -10,8 +10,8 @@ public extension AsyncSequence {
     ///
     ///  - Tip: ``share()`` is effectively a shortcut for ``multicast()`` using a ``Passthrough`` stream, with an implicit ``autoconnect()``.
     ///
-    /// The following example uses an async sequence as a counter to emit three random numbers. Each element is delayed by 1s to give the seconf loop a chance to
-    /// catch all the values.
+    /// The following example uses an async sequence as a counter to emit three random numbers.
+    /// Each element is delayed by 1s to give the seconf loop a chance to catch all the values.
     ///
     /// ```
     ///     let sharedAsyncSequence = AsyncSequences.From(["first", "second", "third"], interval: .seconds(1))
@@ -40,7 +40,8 @@ public extension AsyncSequence {
     ///     // Stream 2 received: ("Third", 61)
     ///     // Stream 1 received: ("Third", 61)
     /// ```
-    /// In this example, the output shows that the upstream async sequence produces each random value only one time, and then sends the value to both client loops.
+    /// In this example, the output shows that the upstream async sequence produces each random value only one time,
+    /// and then sends the value to both client loops.
     ///
     /// Without the ``share()`` operator, loop 1 receives three random values, followed by loop 2 receiving three different random values.
     ///
@@ -53,7 +54,6 @@ public extension AsyncSequence {
     }
 }
 
-extension AsyncSequences {
-    public typealias AsyncShareSequence<UpstreamAsyncSequence: AsyncSequence> =
-    AsyncMulticastSequence<UpstreamAsyncSequence,AsyncStreams.Passthrough<UpstreamAsyncSequence.Element>>
+public extension AsyncSequences {
+    typealias AsyncShareSequence<S: AsyncSequence> = AsyncMulticastSequence<S, AsyncStreams.Passthrough<S.Element>>
 }

--- a/Sources/Operators/AsyncSequence+Share.swift
+++ b/Sources/Operators/AsyncSequence+Share.swift
@@ -1,0 +1,59 @@
+//
+//  AsyncSequence+Share.swift
+//  
+//
+//  Created by Thibault Wittemberg on 03/03/2022.
+//
+
+public extension AsyncSequence {
+    /// Shares the output of an upstream async sequence with multiple client loops.
+    ///
+    ///  - Tip: ``share()`` is effectively a shortcut for ``multicast()`` using a ``Passthrough`` stream, with an implicit ``autoconnect()``.
+    ///
+    /// The following example uses an async sequence as a counter to emit three random numbers. Each element is delayed by 1s to give the seconf loop a chance to
+    /// catch all the values.
+    ///
+    /// ```
+    ///     let sharedAsyncSequence = AsyncSequences.From(["first", "second", "third"], interval: .seconds(1))
+    ///         .map { ($0, Int.random(in: 0...100)) }
+    ///         .handleEvents(onElement: { print("AsyncSequence produces: \($0)") })
+    ///         .share()
+    ///
+    ///     Task {
+    ///         try await sharedAsyncSequence
+    ///             .collect { print ("Task 1 received: \($0)") }
+    ///     }
+    ///
+    ///     Task {
+    ///         try await sharedAsyncSequence
+    ///             .collect { print ("Task 2 received: \($0)") }
+    ///     }
+    ///
+    ///     // will print:
+    ///     // AsyncSequence produces: ("First", 78)
+    ///     // Stream 2 received: ("First", 78)
+    ///     // Stream 1 received: ("First", 78)
+    ///     // AsyncSequence produces: ("Second", 98)
+    ///     // Stream 2 received: ("Second", 98)
+    ///     // Stream 1 received: ("Second", 98)
+    ///     // AsyncSequence produces: ("Third", 61)
+    ///     // Stream 2 received: ("Third", 61)
+    ///     // Stream 1 received: ("Third", 61)
+    /// ```
+    /// In this example, the output shows that the upstream async sequence produces each random value only one time, and then sends the value to both client loops.
+    ///
+    /// Without the ``share()`` operator, loop 1 receives three random values, followed by loop 2 receiving three different random values.
+    ///
+    /// Also note that ``AsyncShareSequence`` is a class rather than a structure like most other publishers.
+    /// This means you can use this operator to create a publisher instance that uses reference semantics.
+    /// - Returns: A class instance that shares elements received from its upstream async sequence to multiple client loops.
+    func share() -> AsyncSequences.AsyncShareSequence<Self> {
+        let stream = AsyncStreams.Passthrough<Element>()
+        return self.multicast(stream).autoconnect()
+    }
+}
+
+extension AsyncSequences {
+    public typealias AsyncShareSequence<UpstreamAsyncSequence: AsyncSequence> =
+    AsyncMulticastSequence<UpstreamAsyncSequence,AsyncStreams.Passthrough<UpstreamAsyncSequence.Element>>
+}

--- a/Tests/Operators/AsyncSequence+ShareTests.swift
+++ b/Tests/Operators/AsyncSequence+ShareTests.swift
@@ -1,0 +1,38 @@
+//
+//  AsyncSequence+ShareTests.swift
+//  
+//
+//  Created by Thibault Wittemberg on 03/03/2022.
+//
+
+import AsyncExtensions
+import XCTest
+
+final class AsyncSequence_ShareTests: XCTestCase {
+    func test_share_multicasts_values_to_clientLoops() {
+        let tasksHaveFinishedExpectation = expectation(description: "the tasks have finished")
+        tasksHaveFinishedExpectation.expectedFulfillmentCount = 2
+
+        let sut = AsyncSequences
+            .From(["first", "second", "third"], interval: .milliSeconds(500))
+            .share()
+
+        Task {
+            var received = [String]()
+            try await sut
+                .collect { received.append($0) }
+            XCTAssertEqual(received, ["first", "second", "third"])
+            tasksHaveFinishedExpectation.fulfill()
+        }
+
+        Task {
+            var received = [String]()
+            try await sut
+                .collect { received.append($0) }
+            XCTAssertEqual(received, ["first", "second", "third"])
+            tasksHaveFinishedExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+    }
+}


### PR DESCRIPTION
## Description
This PR adds the `share()` operator, which is a shortcut for `multicast(_:)` using a `Passthrough` stream.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on the **main** branch and is up-to-date, if not please rebase your branch on the top of **main**
- [x] the commits inside this PR have explicit commit messages
- [x] unit tests cover the new feature or the bug fix
- [x] the feature is documented in the README.md if it makes sense
- [x] the CHANGELOG is up-to-date
