### PR TITLE
operators: handle errors in other for withLatestFrom

### DIFF
--- a/Sources/Operators/AsyncSequence+SwitchToLatest.swift
+++ b/Sources/Operators/AsyncSequence+SwitchToLatest.swift
@@ -22,7 +22,8 @@ public extension AsyncSequence where Element: AsyncSequence {
     /// // will print:
     /// a3, b3
     /// ```
-    /// - parameter upstreamPriority: can be used to change the priority of the task that supports the iteration over the upstream sequence (nil by default)
+    /// - parameter upstreamPriority: can be used to change the priority of the task that supports the iteration
+    /// over the upstream sequence (nil by default)
     ///
     /// - Returns: The async sequence that republishes elements sent by the most recently received async sequence.
     func switchToLatest(upstreamPriority: TaskPriority? = nil) -> AsyncSwitchToLatestSequence<Self> {


### PR DESCRIPTION
## Description
This PR improves the error management for withLatestFrom when the other sequence fails.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] this PR is based on the **main** branch and is up-to-date, if not please rebase your branch on the top of **main**
- [X] the commits inside this PR have explicit commit messages
- [X] unit tests cover the new feature or the bug fix
- [X] the feature is documented in the README.md if it makes sense
- [X] the CHANGELOG is up-to-date
