### PR TITLE
Fix race condition in `AsyncCurrentValueSubject`

### DIFF
--- a/Sources/AsyncSubjects/AsyncCurrentValueSubject.swift
+++ b/Sources/AsyncSubjects/AsyncCurrentValueSubject.swift
@@ -91,8 +91,8 @@ public final class AsyncCurrentValueSubject<Element>: AsyncSubject where Element
   func handleNewConsumer() -> (iterator: AsyncBufferedChannel<Element>.Iterator, unregister: @Sendable () -> Void) {
     let asyncBufferedChannel = AsyncBufferedChannel<Element>()
 
-    let (terminalState, current) = self.state.withCriticalRegion { state -> (Termination?, Element) in
-      (state.terminalState, state.current)
+    let terminalState = self.state.withCriticalRegion { state -> Termination? in
+      state.terminalState
     }
 
     if let terminalState = terminalState, terminalState.isFinished {
@@ -100,11 +100,10 @@ public final class AsyncCurrentValueSubject<Element>: AsyncSubject where Element
       return (asyncBufferedChannel.makeAsyncIterator(), {})
     }
 
-    asyncBufferedChannel.send(current)
-
     let consumerId = self.state.withCriticalRegion { state -> Int in
       state.ids += 1
       state.channels[state.ids] = asyncBufferedChannel
+      asyncBufferedChannel.send(state.current)
       return state.ids
     }
 

--- a/Sources/AsyncSubjects/AsyncThrowingCurrentValueSubject.swift
+++ b/Sources/AsyncSubjects/AsyncThrowingCurrentValueSubject.swift
@@ -97,8 +97,8 @@ public final class AsyncThrowingCurrentValueSubject<Element, Failure: Error>: As
   ) -> (iterator: AsyncThrowingBufferedChannel<Element, Error>.Iterator, unregister: @Sendable () -> Void) {
     let asyncBufferedChannel = AsyncThrowingBufferedChannel<Element, Error>()
 
-    let (terminalState, current) = self.state.withCriticalRegion { state -> (Termination?, Element) in
-      (state.terminalState, state.current)
+    let terminalState = self.state.withCriticalRegion { state -> Termination? in
+      state.terminalState
     }
 
     if let terminalState = terminalState {
@@ -111,11 +111,10 @@ public final class AsyncThrowingCurrentValueSubject<Element, Failure: Error>: As
       return (asyncBufferedChannel.makeAsyncIterator(), {})
     }
 
-    asyncBufferedChannel.send(current)
-
     let consumerId = self.state.withCriticalRegion { state -> Int in
       state.ids += 1
       state.channels[state.ids] = asyncBufferedChannel
+      asyncBufferedChannel.send(state.current)
       return state.ids
     }
 


### PR DESCRIPTION
## Description
If a value is sent to the subject while `handleNewConsumer()` is running, it is possible for the new consumer to miss this value. This is because the `currentValue` is read before the state is updated with the channel. This is addressed by setting the current value at the same point that the channel is added to the state.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on the **main** branch and is up-to-date, if not please rebase your branch on the top of **main**
- [x] the commits inside this PR have explicit commit messages
- [ ] unit tests cover the new feature or the bug fix
- [x] the feature is documented in the README.md if it makes sense
- [ ] the CHANGELOG is up-to-date
