### PR TITLE
Add support for a throwing `onStart` closure in the `AsyncHandleEventsSequence`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+**v0.5.5 - Sodium:**
+
+This version add support for a throwing `onStart` closure in the `AsyncHandleEventsSequence`.
+
+**v0.5.4 - Neon:**
+
+This release conforms AnyAsyncSequence to Sendable.
+
+**v0.5.3 - Fluorine:**
+
+The release fixes a conflict on the Failure primary associated type newly defined in Swift.
+
+- Fix Xcode 16 build failure caused by AsyncSubject (https://github.com/sideeffect-io/AsyncExtensions/pull/42)
+
 **v0.5.2 - Oxygen:**
 
 This version is a bug fix version.


### PR DESCRIPTION
## Description
This adds support for throwing an error on the first iteration of a sequence, with the `onStart` closure, propagating the error to the `onFinish` closure as well.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] this PR is based on the **main** branch and is up-to-date, if not please rebase your branch on the top of **main**
- [x] the commits inside this PR have explicit commit messages
- [x] unit tests cover the new feature or the bug fix
- [x] the feature is documented in the README.md if it makes sense
- [x] the CHANGELOG is up-to-date
